### PR TITLE
Fix #25: Changed base file name for "slim" JAR

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ task fatJar(type: Jar) {
         attributes 'Main-Class': 'gedinline.main.Main'
     }
 
-    archiveBaseName = 'gedinline'
+    archiveBaseName = 'gedinline-fat'
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,10 @@ test {
     outputs.upToDateWhen { false }
 }
 
+jar {
+    archiveBaseName = 'gedinline-slim'
+}
+
 task fatJar(type: Jar) {
     dependsOn 'test'
 
@@ -42,7 +46,7 @@ task fatJar(type: Jar) {
         attributes 'Main-Class': 'gedinline.main.Main'
     }
 
-    archiveBaseName = 'gedinline-fat'
+    archiveBaseName = 'gedinline'
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     from { configurations.runtimeClasspath.collect { it.isDirectory() ? it : zipTree(it) } }


### PR DESCRIPTION
As described in #25 publishing to jitpack.io fails due to building error:

> A problem was found with the configuration of task ':publishGedinlinePublicationToMavenLocal' (type 'PublishToMavenLocal').
> Gradle detected a problem with the following location: '/home/jitpack/build/build/libs/gedinline-4.0.1.jar'.  
> Reason: Task ':publishGedinlinePublicationToMavenLocal' uses this output of task ':jar' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.

The problem is that both the tasks `jar` and `fatJar` create files with the same name. Therefore, changing the name of one output file solves the problem:

https://jitpack.io/com/github/cbettinger/gedinline/-dfdc479752-1/build.log

Since you seem to prefer deploying the fat JAR, I changed the base file name for the unused "slim" JAR to `gedinline-slim`.